### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The purpose is the demonstration customize `/` search by nvim-cmp.
 # Setup
 
 ```lua
-require'cmp'.cmdline.setup('/', {
+require'cmp'.setup.cmdline('/', {
   sources = cmp.config.sources({
     { name = 'nvim_lsp_document_symbol' }
   }, {


### PR DESCRIPTION
There was a small typo in the setup code given in the README