### PR TITLE
feat: use `selectionRange` to detect symbol start line

### DIFF
--- a/lua/cmp_nvim_lsp_document_symbol/init.lua
+++ b/lua/cmp_nvim_lsp_document_symbol/init.lua
@@ -59,12 +59,12 @@ source.complete = function(self, _, callback)
       for _, node in ipairs(nodes) do
         local kind_name = SymbolKind[node.kind]
         if vim.tbl_contains({ 'Module', 'Namespace', 'Object', 'Class', 'Interface', 'Method', 'Function' }, kind_name) then
-          local line = vim.api.nvim_buf_get_lines(0, node.range.start.line, node.range.start.line + 1, false)[1] or ''
+          local line = vim.api.nvim_buf_get_lines(0, node.selectionRange.start.line, node.selectionRange.start.line + 1, false)[1] or ''
           table.insert(items, {
             label = ('%s%s'):format(string.rep(' ', level), string.gsub(line, '^%s*', '')),
-            insertText = ('\\%%%sl'):format(node.range.start.line + 1),
+            insertText = ('\\%%%sl'):format(node.selectionRange.start.line + 1),
             filterText = '@' .. node.name,
-            sortText = '' .. node.range.start.line,
+            sortText = '' .. node.selectionRange.start.line,
             kind = node.kind,
             data = node,
           })

--- a/lua/cmp_nvim_lsp_document_symbol/init.lua
+++ b/lua/cmp_nvim_lsp_document_symbol/init.lua
@@ -59,12 +59,13 @@ source.complete = function(self, _, callback)
       for _, node in ipairs(nodes) do
         local kind_name = SymbolKind[node.kind]
         if vim.tbl_contains({ 'Module', 'Namespace', 'Object', 'Class', 'Interface', 'Method', 'Function' }, kind_name) then
-          local line = vim.api.nvim_buf_get_lines(0, node.selectionRange.start.line, node.selectionRange.start.line + 1, false)[1] or ''
+          local range = node.selectionRange or node.range
+          local line = vim.api.nvim_buf_get_lines(0, range.start.line, range.start.line + 1, false)[1] or ''
           table.insert(items, {
             label = ('%s%s'):format(string.rep(' ', level), string.gsub(line, '^%s*', '')),
-            insertText = ('\\%%%sl'):format(node.selectionRange.start.line + 1),
+            insertText = ('\\%%%sl'):format(range.start.line + 1),
             filterText = '@' .. node.name,
-            sortText = '' .. node.selectionRange.start.line,
+            sortText = '' .. range.start.line,
             kind = node.kind,
             data = node,
           })


### PR DESCRIPTION
This PR changes usage of `range` property of `DocumentSymbol` to `selectionRange`.

### Current behavior

If there are docblocks in the document then plugin takes first line of the docblock, which is usually includes only `/**` string.

![Screenshot_20221021_154401](https://user-images.githubusercontent.com/1159520/197166497-c7db2dec-8a7a-4b0a-8c77-4728c5805755.png)

As the [documentation for document symbol request](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentSymbol) states, `range` property of `DocumentSymbol` includes comments surrounding the symbol, while `selectionRange` don't.

### New behavior

With this patch applied completion system shows first line of the symbol skipping comment block.

![Screenshot_20221021_155151](https://user-images.githubusercontent.com/1159520/197167947-ba272f7f-2cff-437c-8f13-ed9e7247aacf.png)