### PR TITLE
fix!: deprecated `buf_get_clients` -> `get_clients { bufnr = 0 }`

### DIFF
--- a/lua/cmp_nvim_lsp_document_symbol/init.lua
+++ b/lua/cmp_nvim_lsp_document_symbol/init.lua
@@ -82,7 +82,7 @@ source.complete = function(self, _, callback)
 end
 
 source._get_client = function(self)
-  for _, client in pairs(vim.lsp.buf_get_clients()) do
+  for _, client in pairs(vim.lsp.get_clients({ bufnr = 0 })) do
     if self:_get(client.server_capabilities, { 'documentSymbolProvider' }) then
       return client
     end


### PR DESCRIPTION
`vim.lsp.buf_get_clients` is deprecated in nightly.
This probably breaks compatibility with older Neovim versions

